### PR TITLE
Add multi-notation modeler

### DIFF
--- a/app/MultiNotationModeler/MultiNotationPalette.js
+++ b/app/MultiNotationModeler/MultiNotationPalette.js
@@ -1,0 +1,157 @@
+import { assign } from 'min-dash';
+import inherits from 'inherits';
+import BasePaletteProvider from '../baseModeler/BasePaletteProvider';
+
+/**
+ * Palette provider that merges Example and PPINOT palettes
+ */
+export default function MultiNotationPaletteProvider(
+  palette, create, elementFactory,
+  spaceTool, lassoTool, handTool,
+  globalConnect, translate) {
+
+  // Instantiate notation-specific palettes
+  this._examplePalette = new ExampleNotationPalette(create, elementFactory, translate);
+  this._ppinotPalette = new PPINOTNotationPalette(create, elementFactory, translate);
+
+  // Call parent constructor with both palettes
+  BasePaletteProvider.call(this, palette, create, elementFactory,
+    spaceTool, lassoTool, handTool, globalConnect, translate,
+    [this._examplePalette, this._ppinotPalette]);
+}
+
+inherits(MultiNotationPaletteProvider, BasePaletteProvider);
+
+MultiNotationPaletteProvider.$inject = [
+  'palette',
+  'create',
+  'elementFactory',
+  'spaceTool',
+  'lassoTool',
+  'handTool',
+  'globalConnect',
+  'translate'
+];
+
+/**
+ * Example notation palette entries
+ */
+function ExampleNotationPalette(create, elementFactory, translate) {
+  this._create = create;
+  this._elementFactory = elementFactory;
+  this._translate = translate;
+}
+
+ExampleNotationPalette.prototype.getPaletteEntries = function() {
+  var create = this._create,
+      elementFactory = this._elementFactory,
+      translate = this._translate;
+
+  function createAction(type, group, className, title, options) {
+    function createListener(event) {
+      var shape = elementFactory.createShape(assign({ type: type }, options));
+      shape.color = '#000';
+      if (options) {
+        shape.businessObject.di.isExpanded = options.isExpanded;
+      }
+      create.start(event, shape);
+    }
+
+    var shortType = type.replace(/^Example:/, '');
+
+    return {
+      group: group,
+      className: className,
+      title: title || 'Create ' + shortType,
+      action: {
+        dragstart: createListener,
+        click: createListener
+      }
+    };
+  }
+
+  return {
+    'Example-separator': {
+      group: 'Example',
+      separator: true
+    },
+    'Example-element1': createAction(
+      'Example:Element1', 'Example', 'icon-example-element1',
+      translate('Create Example Element 1')
+    ),
+    'Example-element2': createAction(
+      'Example:Element2', 'Example', 'icon-example-element2',
+      translate('Create Example Element 2')
+    ),
+    'Example-connector': createAction(
+      'Example:Connector', 'Example', 'icon-example-connector',
+      translate('Create Example Connector')
+    )
+  };
+};
+
+/**
+ * PPINOT notation palette entries
+ */
+function PPINOTNotationPalette(create, elementFactory, translate) {
+  this._create = create;
+  this._elementFactory = elementFactory;
+  this._translate = translate;
+}
+
+PPINOTNotationPalette.prototype.getPaletteEntries = function() {
+  var create = this._create,
+      elementFactory = this._elementFactory,
+      translate = this._translate;
+
+  function createAction(type, group, className, title, options) {
+    function createListener(event) {
+      var shape = elementFactory.createShape(assign({ type: type }, options));
+      shape.color = '#000';
+      if (options) {
+        shape.businessObject.di.isExpanded = options.isExpanded;
+      }
+      create.start(event, shape);
+    }
+
+    var shortType = type.replace(/^PPINOT:/, '');
+
+    return {
+      group: group,
+      className: className,
+      title: title || 'Create ' + shortType,
+      action: {
+        dragstart: createListener,
+        click: createListener
+      }
+    };
+  }
+
+  return {
+    'PPINOT-separator': {
+      group: 'PPINOT',
+      separator: true
+    },
+    'PPINOT-baseMeasure': createAction(
+      'PPINOT:BaseMeasure', 'PPINOT', 'icon-baseMeasure',
+      translate('Create Base Measure')
+    ),
+    'PPINOT-aggregatedMeasure': createAction(
+      'PPINOT:AggregatedMeasure', 'PPINOT', 'icon-PPINOT-aggregatedMeasure',
+      translate('Create Aggregated Measure')
+    ),
+    'PPINOT-ppi': createAction(
+      'PPINOT:Ppi', 'PPINOT', 'icon-PPINOT-ppi',
+      translate('Create PPI')
+    ),
+    'PPINOT-target': createAction(
+      'PPINOT:Target', 'PPINOT', 'icon-target',
+      translate('Create Target')
+    ),
+    'PPINOT-scope': createAction(
+      'PPINOT:Scope', 'PPINOT', 'icon-scope',
+      translate('Create Scope')
+    )
+  };
+};
+

--- a/app/MultiNotationModeler/index.js
+++ b/app/MultiNotationModeler/index.js
@@ -1,0 +1,64 @@
+import inherits from 'inherits';
+import PPINOTModeler from '../PPINOT-modeler';
+import MultiNotationPaletteProvider from './MultiNotationPalette';
+import PPINOTContextPadProvider from '../PPINOT-modeler/PPINOT/PPINOTContextPadProvider';
+import PPINOTElementFactory from '../PPINOT-modeler/PPINOT/PPINOTElementFactory';
+import PPINOTOrderingProvider from '../PPINOT-modeler/PPINOT/PPINOTOrderingProvider';
+import PPINOTRenderer from '../PPINOT-modeler/PPINOT/PPINOTRenderer';
+import PPINOTRules from '../PPINOT-modeler/PPINOT/PPINOTRules';
+import PPINOTUpdater from '../PPINOT-modeler/PPINOT/PPINOTUpdater';
+import PPINOTBpmnUpdater from '../PPINOT-modeler/PPINOT/PPINOTBpmnUpdater';
+import PPINOTLabelEditingProvider from '../PPINOT-modeler/PPINOT/PPINOTLabelEditingProvider';
+import PPINOTModeling from '../PPINOT-modeler/PPINOT/PPINOTModeling';
+import PPINOTConnect from '../PPINOT-modeler/PPINOT/PPINOTConnect';
+import PPINOTReplaceConnectionBehavior from '../PPINOT-modeler/PPINOT/behaviour/ReplaceConnectionBehaviour';
+import PPINOTReplaceMenuProvider from '../PPINOT-modeler/PPINOT/PPINOTReplaceMenuProvider';
+import PPINOTReplace from '../PPINOT-modeler/PPINOT/PPINOTReplace';
+import PPINOTCustomTextEditor from '../PPINOT-modeler/PPINOT/PPINOTCustomTextEditor';
+
+// Module that replaces the palette provider with one supporting multiple notations
+var MultiNotationModule = {
+  __init__: [
+    'contextPadProvider',
+    'PPINOTOrderingProvider',
+    'PPINOTRenderer',
+    'PPINOTRules',
+    'PPINOTUpdater',
+    'paletteProvider',
+    'PPINOTLabelEditingProvider',
+    'modeling',
+    'connect',
+    'replaceConnectionBehavior',
+    'replaceMenuProvider',
+    'replace',
+    'bpmnUpdater',
+    'customTextEditor'
+  ],
+  contextPadProvider: ['type', PPINOTContextPadProvider],
+  PPINOTOrderingProvider: ['type', PPINOTOrderingProvider],
+  PPINOTRenderer: ['type', PPINOTRenderer],
+  PPINOTRules: ['type', PPINOTRules],
+  PPINOTUpdater: ['type', PPINOTUpdater],
+  elementFactory: ['type', PPINOTElementFactory],
+  paletteProvider: ['type', MultiNotationPaletteProvider],
+  PPINOTLabelEditingProvider: ['type', PPINOTLabelEditingProvider],
+  modeling: ['type', PPINOTModeling],
+  connect: ['type', PPINOTConnect],
+  replaceConnectionBehavior: ['type', PPINOTReplaceConnectionBehavior],
+  replaceMenuProvider: ['type', PPINOTReplaceMenuProvider],
+  bpmnUpdater: ['type', PPINOTBpmnUpdater],
+  replace: ['type', PPINOTReplace],
+  customTextEditor: ['type', PPINOTCustomTextEditor]
+};
+
+// Modeler that loads the multi-notation module
+export default function MultiNotationModeler(options) {
+  PPINOTModeler.call(this, options);
+}
+
+inherits(MultiNotationModeler, PPINOTModeler);
+
+MultiNotationModeler.prototype._modules = [].concat(
+  MultiNotationModeler.prototype._modules,
+  [ MultiNotationModule ]
+);

--- a/app/app.js
+++ b/app/app.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import PPINOTModeler from './PPINOT-modeler';
+import MultiNotationModeler from './MultiNotationModeler';
 import BpmnModdle from 'bpmn-moddle';
 import PPINOTDescriptor from './PPINOT-modeler/PPINOT/PPINOT.json';
 import SubprocessNavigation from './PPINOT-modeler/PPINOT/utils/NavigationUtil';
@@ -8,7 +8,8 @@ const moddle = new BpmnModdle({});
 const container = $('#js-drop-zone');
 const body = $('body');
 
-const modeler = new PPINOTModeler({
+// Use the multi-notation modeler so both notations can be used simultaneously
+const modeler = new MultiNotationModeler({
   container: '#js-canvas',
   moddleExtensions: {
     PPINOT: PPINOTDescriptor 


### PR DESCRIPTION
## Summary
- implement MultiNotationPaletteProvider merging Example and PPINOT palettes
- add MultiNotationModeler extending existing PPINOT modeler
- wire the application to use the multi-notation modeler

## Testing
- `npm run lint` *(fails: Parsing errors and unused variables in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_684ff2f63890832e84af162fbc446f9a